### PR TITLE
change jinja lstrip in stop_spark.sh.j2

### DIFF
--- a/ansible/roles/run-spark-cluster/templates/stop_spark.sh.j2
+++ b/ansible/roles/run-spark-cluster/templates/stop_spark.sh.j2
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-{%- if inventory_hostname in groups['sparkmaster'] %}
+{% if inventory_hostname in groups['sparkmaster'] %}
 docker stop spark-master
 {% endif %}
 


### PR DESCRIPTION
This fixes an lstrip which causes the stop script on the spark master to look like:

```
#!/bin/bashdocker stop spark-master

docker stop spark-worker
```
it should instead render like:
```
#!/bin/bash

docker stop spark-master
docker stop spark-worker
```
