### PR TITLE
RING-44102 - git archive prefix spark/ ~ playbooks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           sudo apt-get install -y makeself
       - name: Create Archive from Spark
         run: |
-          git archive --output=${{ env.staging_path }}/spark-repo.tar --format=tar HEAD
+          git archive --prefix=spark/ --output=${{ env.staging_path }}/spark-repo.tar --format=tar HEAD
       - name: Pull containers from ${{ env.registry }}
         run: |
           docker pull ${{ env.registry }}/spark/spark-master:latest

--- a/ansible/roles/stage-spark-cluster/templates/setup.sh.j2
+++ b/ansible/roles/stage-spark-cluster/templates/setup.sh.j2
@@ -17,4 +17,4 @@ ${sudo} cd ../ && mv ./staging /var/tmp/
 ${sudo} tar -C /root -x -v -f {{ staging_path }}spark-repo.tar spark/ansible
 ${sudo} echo -e "{{ staging_archive }} has extracted itself.\n"
 ${sudo} echo -e "To continue with the staged deployment cd into ~/spark/ansible"
-${sudo} echo -e"and execute run.yml without the staging tag."
+${sudo} echo -e "and execute run.yml without the staging tag."

--- a/scripts/offline-archive-setup.sh
+++ b/scripts/offline-archive-setup.sh
@@ -17,4 +17,4 @@ ${sudo} cd ../ && mv ./staging /var/tmp/
 ${sudo} tar -C /root -x -v -f /var/tmp/staging/spark-repo.tar spark/ansible
 ${sudo} echo -e "spark-offline-archive.run has extracted itself.\n"
 ${sudo} echo -e "To continue with the staged deployment cd into ~/spark/ansible"
-${sudo} echo -e"and execute run.yml without the staging tag."
+${sudo} echo -e "and execute run.yml without the staging tag."


### PR DESCRIPTION
Uses the prefix `spark/` the same way the staging playbook that created the original spark offline archive did, persisting the same logic for the offline-archive-setup.sh/setup.sh script, and each playbook accessing the `spark-repo.tar` file.