### PR TITLE
automatically create a prerelease for testing created tags before a GA release.

### DIFF
--- a/.github/workflows/prerelease-tag-create.yml
+++ b/.github/workflows/prerelease-tag-create.yml
@@ -1,0 +1,13 @@
+name: Create Prerelease on tag creation
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  call-release-workflow:
+    uses: scality/spark/.github/workflows/release.yml@master
+    with:
+      tag: ${{  github.ref_name }}
+      prerelease: true


### PR DESCRIPTION
Simplifies the testing process by starting a prerelease for any newly created tag. This still requires approval for release/deployment workflows. 

- A scheduled prerelease cleanup happens at 4AM daily.

- The GA release still requires a manual release 