### PR TITLE
automatically create a prerelease for testing created tags before a GA release.

### DIFF
--- a/.github/workflows/prerelease-tag-create.yml
+++ b/.github/workflows/prerelease-tag-create.yml
@@ -1,0 +1,13 @@
+name: Create Prerelease on tag creation
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  call-release-workflow:
+    uses: scality/spark/.github/workflows/release.yml@master
+    with:
+      tag: ${{ github.ref_name }}
+      prerelease: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,22 @@
 name: Create Release
 
 on:
+  workflow_call:
+    inputs:
+        tag:
+          description: Tag to use generating offline installer
+          type: string
+          required: true
+        prerelease:
+          description: Is the release a pre release?
+          type: boolean
+          required: false
+          default: false
   workflow_dispatch:
     inputs:
       tag:
         description: Tag to use generating offline installer
+        type: string
         required: true
       prerelease:
         description: Is the release a pre release?


### PR DESCRIPTION
- working workflow_call w/ inputs
- type: string (needs to be defined for workflow_calls or default of string not visible in call.)