### PR TITLE
include environment in caller and inherit secrets for callled/reusable

### DIFF
--- a/.github/workflows/prerelease-tag-create.yml
+++ b/.github/workflows/prerelease-tag-create.yml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   call-release-workflow:
+    environment: packages
     uses: scality/spark/.github/workflows/release.yml@master
     with:
       tag: ${{ github.ref_name }}
       prerelease: true
+    secrets: inherit


### PR DESCRIPTION
Even though on workflow_dispatch the environment `packages` appears to populate the secrets, when called as a re-usable workflow the registry login says there are no user/password

```
Run docker/login-action@v2.1.0
  with:
    registry: registry.scality.com
    ecr: auto
    logout: true
  env:
    image_path: spark-dev/deployment
    staging_path: /home/runner/work/spark/spark/staging
    registry: registry.scality.com
    img: fieldreportservice
    image: registry.scality.com/spark-dev/deployment
    staging_archive: spark-offline-archive-0.1.1_auto_tag_test-prerelease.run
Error: Username and password required
```

Adding the environment to the primary workflow, and then setting `secret: inherit` to pass them to the re-usable workflow.