### PR TITLE
reusable release workflow w/ automatic prerelease on tag create

### DIFF
--- a/.github/workflows/prerelease-tag-create.yml
+++ b/.github/workflows/prerelease-tag-create.yml
@@ -1,0 +1,18 @@
+name: Create Prerelease on tag creation
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  call-release-workflow:
+    uses: ./.github/workflows/release.yml
+    with:
+      tag: ${{ github.ref_name }}
+      prerelease: true
+    secrets:
+      REGISTRY_LOGIN: ${{ secrets.REGISTRY_LOGIN }}
+      REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+      PACKAGES_SSH_PRIVATE_KEY: ${{ secrets.PACKAGES_SSH_PRIVATE_KEY }}
+      PACKAGES_SSH_USER: ${{ secrets.PACKAGES_SSH_USER }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,31 @@
 name: Create Release
 
 on:
+  workflow_call:
+    inputs:
+      tag:
+        description: Tag to use generating offline installer
+        type: string
+        required: true
+      prerelease:
+        description: Is the release a pre release?
+        type: boolean
+        required: false
+        default: false
+    secrets:
+      REGISTRY_LOGIN:
+        required: true
+      REGISTRY_PASSWORD:
+        required: true
+      PACKAGES_SSH_PRIVATE_KEY:
+        required: true
+      PACKAGES_SSH_USER:
+        required: true
   workflow_dispatch:
     inputs:
       tag:
         description: Tag to use generating offline installer
+        type: string
         required: true
       prerelease:
         description: Is the release a pre release?


### PR DESCRIPTION
Working, passes only the **env: packages** secrets and not org secrets like **GITHUB_TOKEN** which would collide in the caller to reusable workflow_call secrets. 